### PR TITLE
Fix  notification buffer not updating onclose

### DIFF
--- a/frontend/__tests__/components/Lobby/NotificationNav.test.tsx
+++ b/frontend/__tests__/components/Lobby/NotificationNav.test.tsx
@@ -70,6 +70,7 @@ describe("Render NotificationNav", () => {
             setNotifications: jest.fn(),
             bufferedNotifications: [],
             setBufferedNotifications: jest.fn(),
+            updateNotificationsReadStatuses: jest.fn(),
           }}
         >
           <NotificationCountContext
@@ -95,6 +96,7 @@ describe("Render NotificationNav", () => {
           setNotifications: jest.fn(),
           bufferedNotifications: [],
           setBufferedNotifications: jest.fn(),
+          updateNotificationsReadStatuses: jest.fn(),
         }}
       >
         <NotificationCountContext
@@ -135,6 +137,7 @@ describe("Render NotificationNav", () => {
             setNotifications: jest.fn(),
             bufferedNotifications: [],
             setBufferedNotifications: jest.fn(),
+            updateNotificationsReadStatuses: jest.fn(),
           }}
         >
           <NotificationCountContext
@@ -171,6 +174,7 @@ describe("Render NotificationNav", () => {
               setNotifications: jest.fn(),
               bufferedNotifications: [],
               setBufferedNotifications: jest.fn(),
+              updateNotificationsReadStatuses: jest.fn(),
             }}
           >
             <NotificationCountContext
@@ -210,6 +214,7 @@ describe("Render NotificationNav", () => {
               setNotifications: setNotificationsMock,
               bufferedNotifications: [],
               setBufferedNotifications: setBufferedNotificationMock,
+              updateNotificationsReadStatuses: jest.fn(),
             }}
           >
             <NotificationCountContext
@@ -249,6 +254,7 @@ describe("Render NotificationNav", () => {
                 setNotifications: setNotificationsMock,
                 bufferedNotifications: [notification],
                 setBufferedNotifications: setBufferedNotificationMock,
+                updateNotificationsReadStatuses: jest.fn(),
               }}
             >
               <NotificationCountContext
@@ -293,6 +299,9 @@ describe("Render NotificationNav", () => {
                 setNotifications: setNotificationsMock,
                 bufferedNotifications: [notification],
                 setBufferedNotifications: setBufferedNotificationMock,
+                updateNotificationsReadStatuses: jest.fn(() =>
+                  setBufferedNotificationMock()
+                ),
               }}
             >
               <NotificationCountContext

--- a/frontend/__tests__/components/Notification/NotificationModal.test.tsx
+++ b/frontend/__tests__/components/Notification/NotificationModal.test.tsx
@@ -33,9 +33,6 @@ const notification: NotificationAPI = {
 
 const updatedPayload = "YOU UPDATED THIS NOTIFICATION";
 
-const setIsNotificationModalAnimatingMock = jest.fn();
-const setIsNotificationModalOpenMock = jest.fn();
-
 global.fetch = jest
   .fn()
   .mockImplementationOnce(
@@ -113,6 +110,7 @@ describe(
                 setNotifications: jest.fn(),
                 bufferedNotifications: [],
                 setBufferedNotifications: jest.fn(),
+                updateNotificationsReadStatuses: jest.fn(),
               }}
             >
               <NotificationModalContext
@@ -205,3 +203,166 @@ describe(
     });
   }
 );
+
+const updateNotificationsReadStatusesMock = jest.fn();
+
+describe("Test onClose fn in the NotificationModal", () => {
+  const user = userEvent.setup();
+
+  beforeEach(() => {
+    updateNotificationsReadStatusesMock.mockClear();
+  });
+
+  test(
+    "UpdateNotificationReadStatuses runs when closing the modal with" +
+      " escape key and the notifications is not null and the notifications" +
+      " contains unread notifications",
+    async () => {
+      await act(async () =>
+        render(
+          <NotificationContext
+            value={{
+              notifications: [notification],
+              setNotifications: jest.fn(),
+              bufferedNotifications: [],
+              setBufferedNotifications: jest.fn(),
+              updateNotificationsReadStatuses:
+                updateNotificationsReadStatusesMock,
+            }}
+          >
+            <NotificationModalContext
+              value={{
+                notificationModal: null,
+                isNotificationModalOpen: true,
+                setIsNotificationModalOpen: jest.fn(),
+                setIsNotificationModalAnimating: jest.fn(),
+                isNotificationModalAnimating: false,
+                toggleNotificationModalView: () => {},
+              }}
+            >
+              <NotificationModal />
+            </NotificationModalContext>
+          </NotificationContext>
+        )
+      );
+
+      await user.keyboard("{Escape}");
+      expect(updateNotificationsReadStatusesMock).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  test(
+    "UpdateNotificationReadStatuses doesn't run when closing the modal with" +
+      " escape key when the notifications is falsy",
+    async () => {
+      await act(async () =>
+        render(
+          <NotificationContext
+            value={{
+              notifications: [],
+              setNotifications: jest.fn(),
+              bufferedNotifications: [],
+              setBufferedNotifications: jest.fn(),
+              updateNotificationsReadStatuses:
+                updateNotificationsReadStatusesMock,
+            }}
+          >
+            <NotificationModalContext
+              value={{
+                notificationModal: null,
+                isNotificationModalOpen: true,
+                setIsNotificationModalOpen: jest.fn(),
+                setIsNotificationModalAnimating: jest.fn(),
+                isNotificationModalAnimating: false,
+                toggleNotificationModalView: () => {},
+              }}
+            >
+              <NotificationModal />
+            </NotificationModalContext>
+          </NotificationContext>
+        )
+      );
+
+      await user.keyboard("{Escape}");
+      expect(updateNotificationsReadStatusesMock).toHaveBeenCalledTimes(0);
+    }
+  );
+
+  test(
+    "UpdateNotificationReadStatuses doesn't run when closing the modal with" +
+      " escape key when the notifications doesn't contain unread notifications",
+    async () => {
+      await act(async () =>
+        render(
+          <NotificationContext
+            value={{
+              notifications: [{ ...notification, isRead: true }],
+              setNotifications: jest.fn(),
+              bufferedNotifications: [],
+              setBufferedNotifications: jest.fn(),
+              updateNotificationsReadStatuses:
+                updateNotificationsReadStatusesMock,
+            }}
+          >
+            <NotificationModalContext
+              value={{
+                notificationModal: null,
+                isNotificationModalOpen: true,
+                setIsNotificationModalOpen: jest.fn(),
+                setIsNotificationModalAnimating: jest.fn(),
+                isNotificationModalAnimating: false,
+                toggleNotificationModalView: () => {},
+              }}
+            >
+              <NotificationModal />
+            </NotificationModalContext>
+          </NotificationContext>
+        )
+      );
+
+      await user.keyboard("{Escape}");
+      expect(updateNotificationsReadStatusesMock).toHaveBeenCalledTimes(0);
+    }
+  );
+
+  test(
+    "UpdateNotificationReadStatuses runs when closing the modal with" +
+      " clicking outside of it when the notifications is not null and the" +
+      " notifications contains unread notifications",
+    async () => {
+      await act(async () =>
+        render(
+          <NotificationContext
+            value={{
+              notifications: [notification],
+              setNotifications: jest.fn(),
+              bufferedNotifications: [],
+              setBufferedNotifications: jest.fn(),
+              updateNotificationsReadStatuses:
+                updateNotificationsReadStatusesMock,
+            }}
+          >
+            <NotificationModalContext
+              value={{
+                notificationModal: {
+                  current: document.createElement("div"),
+                },
+                isNotificationModalOpen: true,
+                setIsNotificationModalOpen: jest.fn(),
+                setIsNotificationModalAnimating: jest.fn(),
+                isNotificationModalAnimating: false,
+                toggleNotificationModalView: () => {},
+              }}
+            >
+              <NotificationModal />
+            </NotificationModalContext>
+          </NotificationContext>
+        )
+      );
+
+      const notificationModalContainer = screen.getByTestId("ntfctn-mdl-cntr");
+      await user.click(notificationModalContainer);
+      expect(updateNotificationsReadStatusesMock).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/frontend/__tests__/components/Notification/NotificationRequestItem.test.tsx
+++ b/frontend/__tests__/components/Notification/NotificationRequestItem.test.tsx
@@ -261,7 +261,7 @@ describe("Test NotificationRequestItem's friend request action onSubmit", () => 
     });
   });
 
-  afterEach(() => {
+  beforeEach(() => {
     updateNotificationMock.mockClear();
   });
 

--- a/frontend/src/components/Lobby/NotificationNav.tsx
+++ b/frontend/src/components/Lobby/NotificationNav.tsx
@@ -7,61 +7,13 @@ import {
   NotificationCountContext,
 } from "@/contexts/notification";
 import { NotificationModalContext } from "@/contexts/modal";
-import { postNotificationsReadStatusesToAPI } from "@/api/notification";
-import { NotificationAPI } from "@/types/api";
 
 const NotificationNav = () => {
   const path = usePathname();
   const { notificationCount } = useContext(NotificationCountContext);
-  const { bufferedNotifications, notifications, setBufferedNotifications } =
+  const { notifications, updateNotificationsReadStatuses } =
     useContext(NotificationContext);
   const { toggleNotificationModalView } = useContext(NotificationModalContext);
-
-  type CreateNotificationsReadStatusesFormData = {
-    startDate: string;
-    endDate: string;
-  };
-
-  const createNotificationsReadStatusesFormData = ({
-    startDate,
-    endDate,
-  }: CreateNotificationsReadStatusesFormData) => {
-    const formData = new URLSearchParams();
-    formData.append("startdate", startDate);
-    formData.append("enddate", endDate);
-
-    return formData;
-  };
-
-  type UpdateNotificationsReadStatuses = {
-    notifications: NotificationAPI[];
-  };
-
-  const updateNotificationsReadStatuses = async ({
-    notifications,
-  }: UpdateNotificationsReadStatuses) => {
-    try {
-      const startDate = notifications[0].createdAt;
-      const endDate = notifications[notifications.length - 1].createdAt;
-
-      const formData = createNotificationsReadStatusesFormData({
-        startDate,
-        endDate,
-      });
-
-      const { status, notifications: updatedNotifications } =
-        await postNotificationsReadStatusesToAPI({ formData });
-
-      if (status >= 200 && status <= 300 && updatedNotifications) {
-        setBufferedNotifications([
-          ...bufferedNotifications,
-          ...updatedNotifications,
-        ]);
-      }
-    } catch (err) {
-      if (err instanceof Error) console.log(err.message);
-    }
-  };
 
   return (
     <>

--- a/frontend/src/components/Notification/NotificationModal.tsx
+++ b/frontend/src/components/Notification/NotificationModal.tsx
@@ -18,10 +18,26 @@ const NotificationModal = () => {
     setIsNotificationModalAnimating,
   } = useContext(NotificationModalContext);
 
-  const { notifications, setNotifications } = useContext(NotificationContext);
+  const { notifications, setNotifications, updateNotificationsReadStatuses } =
+    useContext(NotificationContext);
   const [nextCursor, setNextCursor] = useState<null | false | string>(null);
   const nextObserverRef = useRef<null | HTMLDivElement>(null);
   const { user } = useContext(UserContext);
+
+  const checkAndUpdateNotificationsReadStatuses = () => {
+    console.log({ notifications });
+    if (notifications) {
+      /* Only trigger notifications read status update if the
+              notifications contains unread notifications */
+      const containsUnreadNotifications = notifications.some(
+        (notification) => notification.isRead === false
+      );
+
+      if (containsUnreadNotifications) {
+        updateNotificationsReadStatuses({ notifications });
+      }
+    }
+  };
 
   useEffect(() => {
     const fetchNotifications = async () => {
@@ -121,6 +137,7 @@ const NotificationModal = () => {
     const closeOnEsc = (e: KeyboardEvent) => {
       if (e.key === "Escape" && isNotificationModalOpen) {
         closeModal();
+        checkAndUpdateNotificationsReadStatuses();
       }
     };
 
@@ -168,6 +185,7 @@ const NotificationModal = () => {
             if (!isChildren && notificationModal.current !== e.target) {
               setIsNotificationModalOpen(false);
               setIsNotificationModalAnimating(true);
+              checkAndUpdateNotificationsReadStatuses();
             }
           }
         }}

--- a/frontend/src/contexts/notification.ts
+++ b/frontend/src/contexts/notification.ts
@@ -20,6 +20,11 @@ type NotificationContext = {
   setBufferedNotifications: React.Dispatch<
     React.SetStateAction<NotificationAPI[]>
   >;
+  updateNotificationsReadStatuses: ({
+    notifications,
+  }: {
+    notifications: NotificationAPI[];
+  }) => void;
 };
 
 const NotificationContext = createContext<NotificationContext>({
@@ -27,6 +32,7 @@ const NotificationContext = createContext<NotificationContext>({
   setNotifications: () => {},
   bufferedNotifications: [],
   setBufferedNotifications: () => {},
+  updateNotificationsReadStatuses: ({ notifications }) => {},
 });
 
 export { NotificationContext, NotificationCountContext };


### PR DESCRIPTION
Fix  the update notifications' read statuses to run on closing the notification modal, including with pressing the escape keys and clicking outside the modal. This function is previously only when the user clicks the notification nav button.